### PR TITLE
Updated docs to reflect the new Approov 2.6 usage for the `approov secret` command

### DIFF
--- a/docs/APPROOV_QUICK_START.md
+++ b/docs/APPROOV_QUICK_START.md
@@ -32,8 +32,10 @@ The native Kong JWT plugin requires that the Approov Token contains the key ‘k
 In order to set the `kid` for each Approov Token issued we will use the [Approov CLI Tool](https://approov.io/docs/latest/approov-installation/#approov-tool) as mentioned in the [Approov docs](https://approov.io/docs/latest/approov-usage-documentation/#key-ids):
 
 ```
-approov secret path/to/admin.token -setKeyID your-approov-kid-here
+approov secret -setKeyID your-approov-kid-here
 ```
+
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 Please replace `your-approov-kid-here` with the unique identifier you want to use for the Approov Secret in your Kong API Gateway.
 
@@ -62,10 +64,11 @@ curl -i -X POST \
     --header "Content-Type: application/x-www-form-urlencoded" \
     --data algorithm="HS256" \
     --data key=your-approov-kid-here \
-    --data secret=$(approov secret path/to/admin.token -get base64url | head -2 | tail -1)
+    --data secret=$(approov secret -get base64url | head -2 | tail -1)
 ```
 
 >**NOTE:**: We retrieved the Approov secret in a sub shell, because if we had provided it directly then the secret would have been saved into the shell history.
+>**NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 To confirm the Approov Secret was added as the JWT credential we can visit http://localhost:8001/consumers/your-consumer-name-here/jwt.
 

--- a/docs/APPROOV_SECRET.md
+++ b/docs/APPROOV_SECRET.md
@@ -29,8 +29,11 @@ We will use the [Approov CLI Tool](https://approov.io/docs/v2.2/approov-installa
 ##### command:
 
 ```
-approov secret path/to/admin.token -get base64url
+approov secret -get base64url
 ```
+
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
+
 
 ##### output:
 
@@ -64,7 +67,9 @@ The native Kong JWT plugin requires that the Approov Token contains in it's head
 In order to set the `kid` for each Approov Token issued we will use the [Approov CLI Tool](https://approov.io/docs/v2.2/approov-installation/#approov-tool) as mentioned in the [Approov docs](https://approov.io/docs/v2.2/approov-usage-documentation/#key-ids):
 
 ```
-approov secret path/to/admin.token -setKeyID approov
+approov secret -setKeyID approov
 ```
+
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 We used the string `approov` for the identifier, but you are free to use whatsoever unique string identifier for your own project.


### PR DESCRIPTION
Signed-off-by: Exadra37 <exadra37@gmail.com>